### PR TITLE
feat:記録項目の初期データを投入

### DIFF
--- a/app/models/record_item.rb
+++ b/app/models/record_item.rb
@@ -1,5 +1,16 @@
 class RecordItem < ApplicationRecord
     
+  module InputType
+    # 数値入力
+    NUMBER = 1
+    # 選択肢からの単一選択
+    SELECT = 2
+    # テキスト入力
+    TEXT = 3
+    # 評価スライダー
+    RATING = 4
+  end
+
   has_many :record_values, dependent: :destroy
   has_many :user_record_items, dependent: :destroy
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,40 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# 記録項目の初期データ
+puts 'Destroying existing RecordItems...'
+
+RecordItem.destroy_all
+TYPES = RecordItem::InputType
+
+# 初期レコード項目を定義
+initial_items = [
+  {
+    name: '疲労感',
+    input_type: TYPES::RATING,
+    is_default_visible: true,
+  },
+  {
+    name: '意欲',
+    input_type: TYPES::RATING,
+    is_default_visible: true,
+  },
+  {
+    name: '睡眠時間',
+    input_type: TYPES::NUMBER,
+    is_default_visible: true,
+  },
+  {
+    name: '気分',
+    input_type: TYPES::SELECT,
+    is_default_visible: true,
+  },
+  {
+    name: 'フリーメモ',
+    input_type: TYPES::TEXT,
+    is_default_visible: false,
+  }
+]
+
+initial_items.each do |item_data|
+  RecordItem.create!(item_data)
+end
+
+puts "Created #{RecordItem.count} RecordItems."


### PR DESCRIPTION
## 概要
Issue 07「記録項目（record_items）の初期データ投入」の達成条件をすべて満たしました。

## 達成条件
- 初期項目が`seeds.rb`に定義されている
- `input_type`を正しく指定
- `rails db:seed`が正常に動作する

## 修正 or 変更内容
**`RecordItem`モデルの修正**
- `RecordItem::InputType`モジュールを定義し、`NUMBER`, `SELECT`, `RATING`, `TEXT` に対応する数値を定数化しました。

**シードファイルの作成**
- 初期データとして、以下の5つの記録項目を投入しました。
  - 疲労感 (`RATING`)
  - 意欲 (`RATING`)
  - 睡眠時間 (`NUMBER`)
  - 気分 (`SELECT`)
  - フリーメモ (`TEXT`)

- データの重複投入を防ぐため、`RecordItem.destroy_all`を追加しています。

## 動作確認
- `bin/rails db:seed`

![](https://i.gyazo.com/271e7b95128c76ef078a65121ce4e2cd.png)

Resolves #9 