### PR TITLE
feat:活動 CRUD の基盤構築と Record 詳細画面の修正

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,0 +1,60 @@
+class ActivitiesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_record
+  before_action :set_activity, only: %i[show edit update destroy]
+
+  def index
+    @activities = @record.activities.order(start_time: :asc)
+  end
+  
+  def show
+  end
+
+  def new
+    @activity = @record.activities.build
+  end
+
+  def create
+    @activity = @record.activities.build(activity_params)
+
+    if @activity.save
+      redirect_to record_path(@record), notice: '活動を登録しました。'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @activity.update(activity_params)
+      redirect_to record_path(@record), notice: '活動を更新しました。'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @activity.destroy
+    redirect_to record_path(@record), notice: '活動を削除しました。', status: :see_other
+  end
+
+  private
+
+  def set_record
+    @record = current_user.records.find(params[:record_id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to records_path, alert: '指定された記録が見つかりません。'
+  end
+
+  def set_activity
+    @activity = @record.activities.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to record_path(@record), alert: '指定された活動が見つかりません。'
+  end
+
+  def activity_params
+    params.require(:activity).permit(:start_time, :end_time, :content)
+  end
+end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -3,6 +3,7 @@ class Record < ApplicationRecord
 
   has_many :activities, dependent: :destroy
   has_many :record_values, dependent: :destroy
+  has_many :activities, dependent: :destroy
 
   accepts_nested_attributes_for :record_values, allow_destroy: true
   

--- a/app/views/activities/_form.html.slim
+++ b/app/views/activities/_form.html.slim
@@ -1,0 +1,30 @@
+= form_with(model: [record, activity], class: "space-y-4") do |form|
+  - if activity.errors.any?
+    .bg-red-100.border.border-red-400.text-red-700.px-4.py-3.rounded.relative.mb-4
+      p.font-bold = "エラーが #{activity.errors.count} 件あります。"
+      ul.list-disc.list-inside.ml-4
+        - activity.errors.full_messages.each do |message|
+          li = message
+
+  // 開始時刻の入力
+  .field
+    = form.label :start_time, "開始時刻", class: "block text-sm font-medium text-gray-700"
+  .field
+    = form.datetime_field :start_time, required: true, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+
+  // 終了時刻の入力
+  .field
+    = form.label :end_time, "終了時刻", class: "block text-sm font-medium text-gray-700"
+  .field
+    = form.datetime_field :end_time, required: true, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+
+  // 活動内容の入力
+  .field
+    = form.label :content, "活動内容", class: "block text-sm font-medium text-gray-700"
+  .field
+    = form.text_area :content, rows: 3, required: true, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+
+  // 送信ボタン
+  .actions.mt-6
+    = form.submit activity.new_record? ? "活動を記録" : "活動を更新", class: "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 cursor-pointer"
+    = link_to "キャンセル", record_path(record), class: "ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"

--- a/app/views/activities/edit.html.slim
+++ b/app/views/activities/edit.html.slim
@@ -1,0 +1,6 @@
+.max-w-xl.mx-auto.p-6.bg-white.rounded-xl.shadow-2xl.mt-10
+  h1.text-2xl.font-bold.text-gray-800.mb-6.text-center
+    = @record.recorded_date.strftime('%Y年%m月%d日')
+    | の活動を編集
+
+  = render 'form', record: @record, activity: @activity

--- a/app/views/activities/new.html.slim
+++ b/app/views/activities/new.html.slim
@@ -1,0 +1,6 @@
+.max-w-xl.mx-auto.p-6.bg-white.rounded-xl.shadow-2xl.mt-10
+  h1.text-2xl.font-bold.text-gray-800.mb-6.text-center
+    = @record.recorded_date.strftime('%Y年%m月%d日')
+    | の新しい活動を記録
+
+  = render 'form', record: @record, activity: @activity

--- a/app/views/records/_activities_list.html.slim
+++ b/app/views/records/_activities_list.html.slim
@@ -1,0 +1,33 @@
+- activities = record.activities.order(:start_time)
+
+.overflow-x-auto.shadow.rounded-lg
+  - if activities.any?
+    table.min-w-full.divide-y.divide-gray-200
+      thead.bg-gray-100
+        tr
+          th.px-6.py-3.text-left.text-xs.font-medium.text-gray-500.uppercase.tracking-wider
+            | 開始時刻
+          th.px-6.py-3.text-left.text-xs.font-medium.text-gray-500.uppercase.tracking-wider
+            | 終了時刻
+          th.px-6.py-3.text-left.text-xs.font-medium.text-gray-500.uppercase.tracking-wider
+            | 活動内容
+          th.px-6.py-3.text-right.text-xs.font-medium.text-gray-500.uppercase.tracking-wider
+            | アクション
+      
+      tbody.bg-white.divide-y.divide-gray-200
+        - activities.each do |activity|
+          tr
+            td.px-6.py-4.whitespace-nowrap.text-sm.font-medium.text-gray-900
+              = activity.start_time.strftime('%m/%d %H:%M')
+            td.px-6.py-4.whitespace-nowrap.text-sm.text-gray-500
+              = activity.end_time.strftime('%m/%d %H:%M')
+            td.px-6.py-4.text-sm.text-gray-800
+              = activity.content
+            td.px-6.py-4.whitespace-nowrap.text-right.text-sm.font-medium
+              = link_to "編集", edit_record_activity_path(record, activity), class: "text-indigo-600 hover:text-indigo-900"
+              span.mx-2 | |
+              = link_to "削除", record_activity_path(record, activity), data: { turbo_method: :delete, turbo_confirm: "この活動を削除してもよろしいですか？" }, class: "text-red-600 hover:text-red-900"
+  
+  - else
+    .p-6.text-center.text-gray-500.bg-white
+      p.italic この日の活動はまだ記録されていません。

--- a/app/views/records/index.html.slim
+++ b/app/views/records/index.html.slim
@@ -25,7 +25,8 @@
               = truncate(record.diary_memo, length: 50, omission: "...")
           
           .flex.space-x-2.ml-4
-            = link_to '詳細', record_path(record), class: 'text-sm text-indigo-600 hover:underline'
             = link_to '編集', edit_record_path(record), class: 'text-sm text-yellow-600 hover:underline'
-            = link_to 'TOP', authenticated_root_path, class: 'text-sm text-indigo-600 hover:underline'
+            span.mx-2 | |
             = link_to '削除', record_path(record), data: { turbo_method: :delete, turbo_confirm: "本当にこの記録を削除してもよろしいですか？" }, class: 'text-sm text-red-600 hover:underline'
+            span.mx-2 | |
+            = link_to 'TOP', authenticated_root_path, class: 'text-sm text-indigo-600 hover:underline'

--- a/app/views/records/show.html.slim
+++ b/app/views/records/show.html.slim
@@ -1,14 +1,34 @@
-.max-w-2xl.mx-auto.bg-white.p-8.rounded-xl.shadow-2xl.space-y-6
-  h1.text-3xl.font-bold.text-indigo-700.border-b.pb-3.mb-4
-    = @record.recorded_date.strftime('%Y年%m月%d日 の記録')
+.max-w-4xl.mx-auto.p-6.bg-white.rounded-xl.shadow-2xl.mt-10
+  h1.text-3xl.font-extrabold.text-gray-900.mb-4.border-b.pb-2
+    = @record.recorded_date.strftime('%Y年%m月%d日')
+    | の記録
 
-  .detail-section
-    h2.text-xl.font-semibold.text-gray-800.mb-2
-      | 日記/メモ
-    .bg-gray-50.p-4.rounded-lg.text-gray-700.whitespace-pre-wrap
-      = @record.diary_memo.presence || '（メモはありません）'
+  // 記録項目の表示
+  h2.text-2xl.font-bold.text-gray-800.mt-8.mb-4
+    | 体調記録
 
-  .flex.justify-end.space-x-3.border-t.pt-6.mt-6
-    = link_to '編集', edit_record_path(@record), class: 'px-4 py-2 bg-yellow-500 text-white font-medium rounded-lg shadow-md hover:bg-yellow-600 transition duration-150'
-    = link_to '一覧に戻る', records_path, class: 'px-4 py-2 bg-gray-300 text-gray-800 font-medium rounded-lg shadow-md hover:bg-gray-400 transition duration-150'
-    = link_to '削除', record_path(@record), data: { turbo_method: :delete, turbo_confirm: "この記録を完全に削除してもよろしいですか？" }, class: 'px-4 py-2 bg-red-600 text-white font-medium rounded-lg shadow-md hover:bg-red-700 transition duration-150'
+  // 基本情報と編集ボタン
+  .flex.justify-between.items-center.mb-6
+    p.text-gray-600.text-lg
+      | メモ: 
+      span.font-medium.text-gray-800 = @record.diary_memo
+    
+    .actions
+      = link_to "編集", edit_record_path(@record), class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+      span.mx-2 | |
+      = link_to "削除", @record, data: { turbo_method: :delete, turbo_confirm: "この記録を削除してもよろしいですか？" }, class: "ml-3 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-red-600 bg-red-100 hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+      span.mx-2 | |
+      = link_to "詳細", records_path, class: "ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
+
+  .record-values-display.grid.grid-cols-1.md:grid-cols-2.gap-4.bg-gray-50.p-4.rounded-lg.shadow-inner
+    / RecordValueの表示ロジック入れる予定
+
+  // 活動セクション
+  h2.text-2xl.font-bold.text-gray-800.mt-10.mb-4.border-t.pt-6
+    | 活動記録
+  
+  .flex.justify-end.mb-4
+    = link_to "新しい活動を追加", new_record_activity_path(@record), class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+
+  // 活動一覧のパーシャルを呼び出す
+  = render 'activities_list', record: @record

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
 
   resources :records
   
+  resources :records do
+    resources :activities
+  end
+  
   get 'welcome', to: 'welcome#index', as: :welcome
 
   # ログイン済み

--- a/db/migrate/20251125133723_create_activities.rb
+++ b/db/migrate/20251125133723_create_activities.rb
@@ -2,10 +2,9 @@ class CreateActivities < ActiveRecord::Migration[7.1]
   def change
     create_table :activities do |t|
       t.references :record, null: false, foreign_key: true
-      t.datetime :start_time
-      t.datetime :end_time
-      t.text :content
-
+      t.datetime :start_time, null: false
+      t.datetime :end_time, null: false
+      t.text :content, null: false
       t.timestamps
     end
   end


### PR DESCRIPTION
## 概要
Issue 10「活動（activities）の CRUD」の達成条件をすべて満たしました。

## 達成条件
- activitiesの新規作成
- 編集
- 削除
- recordsに紐づけ
- 23:00 → 02:00 のような日付またぎも保存可能

## 修正点 or 変更内容
**Activityモデルの定義と関連付け**
- Recordモデルに`has_many :activities, dependent: :destroy`を追加しました。
- Activityモデルにバリデーションを追加しました。
- `start_time`と`end_time`は`datetime型`としてマイグレーションを作成しました。

**ルーティングのネスト**
- `config/routes.rb`で`resources :activities`を`resources :records`の下にネストさせました。

**ActivitiesControllerの実装**
- ネストされたリソースとしてRecordとActivityを特定する`set_record / set_activity`を実装しました。
- すべての CRUD アクションに認証 (`authenticate_user!`) と厳密なユーザーチェック (`current_user.records.find`) を適用しました。

**ビューの追加**
- `activities/_form.html.slim`(新規作成/編集フォーム) を作成しました。
- `records/_activities_list.html.slim`(活動一覧表示) を作成し、`records/show.html.slim`に組み込みました。

## 動作確認
- `rails routes | grep activities`

![](https://i.gyazo.com/090abebc70fcc2360955da191b8889d4.png)

- `localhost:3000`
![](https://i.gyazo.com/fd05c863e2a46ba98990b2dcc8d8baa0.gif)
- **編集/削除**
![](https://i.gyazo.com/f02beeb5d2ea81fe44940f62488c6afc.gif)
- **23:00 → 02:00 のような日付またぎも保存可能**
![](https://i.gyazo.com/2987348f17c226321b27ea3d381a26f8.gif)

Resolves #12 