### PR TITLE
feat: 日記登録ページにカスタム項目を反映

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -67,7 +67,7 @@
 #timeline {
   position: relative;
   overflow-y: scroll;
-  height: calc(100vh - 200px);
+  max-height: 60vh;
 }
 
 .now-line {

--- a/app/views/record_values/_items_form.html.slim
+++ b/app/views/record_values/_items_form.html.slim
@@ -1,0 +1,9 @@
+/ 記録項目一覧（RecordItemベース）
+.record-items-section.space-y-6
+  - record_items.each do |item|
+    - record_value =
+        record.record_values.find { |rv| rv.record_item_id == item.id } ||
+        record.record_values.build(record_item: item)
+
+    = form.fields_for :record_values, record_value do |record_value_fields|
+      = render 'record_value_fields', f: record_value_fields, item: item

--- a/app/views/records/diary.html.slim
+++ b/app/views/records/diary.html.slim
@@ -1,0 +1,17 @@
+h1.text-center 今日の日記
+
+= form_with model: @record do |f|
+  = f.hidden_field :recorded_date
+
+  .space-y-4.mb-8
+    = f.fields_for :record_values do |rv_f|
+      - if rv_f.object.record_item.user_defined?
+        = render "record_value_fields", f: rv_f
+
+  .diary-section
+    = f.label :diary_memo, "メモ"
+    = f.text_area :diary_memo, class: "form-textarea"
+
+  .mt-6.text-center
+    = f.submit "日記を記録する",
+      class: "inline-flex justify-center py-2 px-6 rounded-md bg-indigo-600 text-white hover:bg-indigo-700"

--- a/app/views/records/health.html.slim
+++ b/app/views/records/health.html.slim
@@ -1,0 +1,13 @@
+h1.text-center 体調管理
+
+= form_with model: @record do |f|
+  = f.hidden_field :recorded_date
+
+  .space-y-4
+    = f.fields_for :record_values do |rv_f|
+      - if rv_f.object.record_item.system?
+        = render "record_value_fields", f: rv_f
+
+  .mt-6.text-center
+    = f.submit "体調を記録する",
+      class: "inline-flex justify-center py-2 px-6 rounded-md bg-indigo-600 text-white hover:bg-indigo-700"

--- a/app/views/records/index.html.slim
+++ b/app/views/records/index.html.slim
@@ -12,7 +12,7 @@
         p.text-sm = "#{l(@date, format: :long)}の記録はまだありません"
 
 / タイムライン
-#timeline.relative[
+#timeline.relative.max-h-screen.overflow-y-auto[
   data-controller="timeline"
   data-timeline-current-hour-value=@current_hour
   data-timeline-current-minute-value=@current_minute
@@ -44,7 +44,16 @@
             method: :post,
             class: "add-button hidden group-hover:flex"
 
+.max-w-2xl.mx-auto.space-y-4.relative.z-20
+  h1.text-2xl.font-bold.text-center 今日の記録
+
+  .flex.justify-center.gap-4
+    = link_to "体調を記録する",health_records_path,class: "px-4 py-2 rounded bg-green-600 text-white"
+    = link_to "日記を書く",diary_records_path,class: "px-4 py-2 rounded bg-blue-600 text-white"
+
+
 / 一応残しておく
+
 .max-w-4xl.mx-auto
   .flex.justify-between.items-center.mb-6
     h1.text-3xl.font-bold.text-gray-800

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,12 @@ Rails.application.routes.draw do
 
   resources :records do
     post :create_with_activity, on: :collection
+
+    collection do
+      get 'health', to: 'records#new_health'
+      get 'diary',  to: 'records#new_diary'
+    end
+
     resources :activities, only: [:new, :create, :edit, :update, :destroy]
     resources :record_values, only: [:create, :update]
     resource  :mood, only: [:new, :create, :edit, :update, :destroy]


### PR DESCRIPTION
## 概要
Issue 16「日記登録ページにカスタム項目を反映させる」の達成条件をすべて満たしました。

## 達成条件
- category = custom の RecordItem
- マイページで非表示にした custom 項目は表示されない
- RecordItem の input_type に応じた入力UIが表示される
- RecordItem の input_type に応じた入力UIが表示される
- text / numeric / checkbox / time_range など
- 日記保存時に、custom 項目の入力内容も保存される

## 修正点 or 変更内容
- `category = custom`の`RecordItem`を日記登録ページに表示しました。
- マイページで非表示にした項目は表示されないよう制御しました。
- `display_order`順で入力フォームを表示しました。
- `input_type`に応じた入力UIを表示しました。（`text / numeric / checkbox / time_range`など）
- 日記保存時に`custom`項目の入力内容も保存しました。
- `_record_value_fields.html.slim` を共通`partial`として`system / custom`で使い分けしました。

## 動作確認
1. マイページで custom 項目を設定する
2. 日記登録ページを開く
3. 設定した項目が display_order 順に表示されることを確認
4. 入力して保存すると RecordValue が作成されることを確認

Resolves #44 