### PR TITLE
fix: カレンダーからの日付指定による日記新規作成時のエラーを解消

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -63,12 +63,9 @@ class RecordsController < ApplicationController
     date = params[:date] ? Date.parse(params[:date]) : Date.current
     @record = current_user.records.find_or_initialize_by(recorded_date: date)
 
-    if @record.new_record?
-      @items = current_user.record_items.user_items.visible.ordered
-      prepare_record_values(@items)
-    end
+    build_missing_record_values(@record)
 
-    render 'diary'
+    render :diary
   end
 
   def edit_diary
@@ -168,6 +165,12 @@ class RecordsController < ApplicationController
   end
 
   private
+
+  def build_missing_record_values(record)
+    current_user.record_items.each do |item|
+      record.record_values.find_or_initialize_by(record_item: item)
+    end
+  end
 
   def set_date
     @date = params[:date] ? Date.parse(params[:date]) : Date.current

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,6 +4,14 @@ class Activity < ApplicationRecord
 
   belongs_to :record
 
+  # バリデーション
+  validates :start_time, presence: true
+  validates :end_time, presence: true
+  validates :content, presence: true, length: { maximum: 500 }
+  
+  # カスタムバリデーション
+  validate :end_time_after_start_time
+
   # タイムライン全体での位置(元のメソッド)
   def top_position
     return 0 unless start_time
@@ -38,5 +46,16 @@ class Activity < ApplicationRecord
     # 次の時間にまたがる場合は、その時間の残り分
     remaining_minutes = 60 - start_time.min
     remaining_minutes * PIXELS_PER_MINUTE
+  end
+
+  private
+
+  def end_time_after_start_time
+    # 開始時刻または終了時刻が空の場合は、presenceバリデーションに任せる
+    return if start_time.blank? || end_time.blank?
+
+    if end_time <= start_time
+      errors.add(:end_time, "は開始時刻よりも後の時刻に設定してください")
+    end
   end
 end

--- a/app/views/records/dashboard.html.slim
+++ b/app/views/records/dashboard.html.slim
@@ -75,7 +75,7 @@ li.border-b.py-4
                     .text-xs.text-gray-500.opacity-0.group-hover:opacity-100.transition-opacity.mt-2 追加
                 - else
                   = link_to create_with_activity_records_path(date: @date, hour: hour), \
-                    method: :post, \
+                    data: { turbo_method: "post" }, \
                     class: "flex-1 relative hover:bg-gray-50 transition flex flex-col items-center justify-center group", \
                     style: "position: relative; min-height: 80px; z-index: 5;"
                     .w-3.h-3.rounded-full.bg-gray-300.group-hover:bg-green-500.group-hover:scale-150.transition-all.duration-200
@@ -90,8 +90,8 @@ li.border-b.py-4
                   .text-xs.text-gray-500.opacity-0.group-hover:opacity-100.transition-opacity.mt-2 追加
               - else
                 = link_to create_with_activity_records_path(date: @date, hour: hour), \
-                  method: :post, \
+                  data: { turbo_method: "post" }, \
                   class: "flex-1 relative hover:bg-gray-50 transition flex flex-col items-center justify-center group", \
-                  style: "position: relative; min-height: 80px;"
+                  style: "position: relative; min-height: 80px; z-index: 5;"
                   .w-3.h-3.rounded-full.bg-gray-300.group-hover:bg-green-500.group-hover:scale-150.transition-all.duration-200
                   .text-xs.text-gray-500.opacity-0.group-hover:opacity-100.transition-opacity.mt-2 追加

--- a/app/views/shared/_date_navigator.html.slim
+++ b/app/views/shared/_date_navigator.html.slim
@@ -1,16 +1,24 @@
 / 日付ナビゲーター(日記)
 .bg-white.rounded-lg.shadow-sm.border.border-gray-200.p-4
   .flex.items-center.justify-between
-    - prev_record = current_user.records.find_by(recorded_date: @record.recorded_date&.prev_day)
-    - next_record = current_user.records.find_by(recorded_date: @record.recorded_date&.next_day)
+    - current_date = @record.recorded_date || Date.current
 
-    = link_to prev_record ? edit_diary_record_path(prev_record) : new_diary_records_path(date: @record.recorded_date&.prev_day), 
-      class: "flex items-center gap-2 text-sm text-indigo-600 hover:text-indigo-800 transition" do
+    / --- 前の日 ---
+    - prev_date = current_date.prev_day
+    - prev_r = current_user.records.find_by(recorded_date: prev_date)
+    - prev_path = prev_r&.diary_memo.to_s.strip.present? ? edit_diary_record_path(prev_r) : new_diary_records_path(date: prev_date)
+
+    = link_to prev_path, class: "flex items-center gap-2 text-sm text-indigo-600 hover:text-indigo-800 transition" do
       i.fas.fa-chevron-left
 
+    / --- 中央の日付表示 ---
     .text-lg.font-bold.text-gray-800
-      = (@record.recorded_date || Date.current).strftime('%Y年%m月%d日')
+      = current_date.strftime('%Y年%m月%d日')
 
-    = link_to next_record ? edit_diary_record_path(next_record) : new_diary_records_path(date: @record.recorded_date&.next_day), 
-      class: "flex items-center gap-2 text-sm text-indigo-600 hover:text-indigo-800 transition" do
+    / --- 次の日 ---
+    - next_date = current_date.next_day
+    - next_r = current_user.records.find_by(recorded_date: next_date)
+    - next_path = next_r&.diary_memo.to_s.strip.present? ? edit_diary_record_path(next_r) : new_diary_records_path(date: next_date)
+
+    = link_to next_path, class: "flex items-center gap-2 text-sm text-indigo-600 hover:text-indigo-800 transition" do
       i.fas.fa-chevron-right

--- a/app/views/shared/_dropdown_menu.html.slim
+++ b/app/views/shared/_dropdown_menu.html.slim
@@ -1,7 +1,11 @@
 .absolute.right-2.top-full.w-48.bg-white.rounded-lg.shadow-lg.border.border-gray-200.hidden.z-50[
   data-menu-target="panel"
 ]
+  - today = Date.current
+  - today_record = current_user.records.find_by(recorded_date: today)
+  - diary_path = today_record&.diary_memo.to_s.strip.present? ? edit_diary_record_path(today_record) : new_diary_records_path(date: today)
+
   ul.py-1
     li
-      = link_to "日記を作成", new_diary_records_path(date: Date.current),
+      = link_to "日記を作成", diary_path, 
         class: "block px-4 py-2 text-gray-700 hover:bg-gray-100 transition"


### PR DESCRIPTION
## 概要
カレンダーの日付選択から日記投稿画面（`new_diary`）へ遷移した際、その日のレコードが存在しない場合に発生していたエラーを解消しました。

## 修正内容
**Controller (RecordsController#new_diary)**
- `params[:date]` に基づいて `find_or_initialize_by` を実行するよう修正し、レコードが存在しない日付でも安全にインスタンス化されるようにしました。
- 日記作成画面を開いた時点で、ユーザーが設定しているカスタム項目（体調など）の入力欄が自動的に準備されるよう `build_missing_record_values` を呼び出すようにしました。

**View (shared/_date_navigator)**
- ナビゲーターにおいて、`@record.recorded_date` が取得できない場合でも `params[:date]` や `Date.current` を基準に日付を表示・リンク生成できるよう修正しました。

## 動作確認
- [x] カレンダーで「記録がない日」を選択し、日記投稿画面が正常に開くこと。
 ![記録がない日](https://i.gyazo.com/ec8e71606233e100d7974ecc2667f3a3.gif)
- [x] その画面で体調（カスタム項目）の入力欄が表示されていること。
 ![日記](https://i.gyazo.com/1bf9dab09c8cb20a5c0857d35b6d1b21.gif)