### PR TITLE
fix: バーチカルカレンダーの活動ブロック表示位置を修正（分単位のオフセット未反映）

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -45,4 +45,4 @@ html
           = link_to "https://x.com/Y_aisia_Y", target: "_blank", rel: "noopener", class: "hover:text-sky-500 transition text-xl" do
             i.fa-brands.fa-x-twitter
 
-        p v1.1.0 / © 2026 jibun-biyori
+        p v1.1.1 / © 2026 jibun-biyori

--- a/app/views/records/dashboard.html.slim
+++ b/app/views/records/dashboard.html.slim
@@ -54,13 +54,14 @@ li.border-b.py-4
                   - duration_minutes = end_min - start_min
                   - total_minutes = duration_hours * 60 + duration_minutes
                   - height_px = (total_minutes / 60.0) * 80
+                  - top_px = (start_min / 60.0) * 80
                   
                   / 時間表示の条件分岐(40分以上は時間表示、35分以下はメモのみ)
                   - show_time = total_minutes >= 40
                   
                   = link_to edit_record_activity_path(@record, presenter.activity), \
                     class: "activity-marker activity-marker-start block no-underline absolute left-0 right-0 bg-blue-100 hover:bg-blue-200 border-l-4 border-blue-500 px-3 py-2 transition", \
-                    style: "top: 0; height: #{height_px}px; z-index: 10;"
+                    style: "top: #{top_px}px; height: #{height_px}px; z-index: 10;"
                     - if show_time
                       .font-medium.text-sm.text-gray-700 = presenter.time_range
                     .mt-1.text-sm.text-gray-600 = presenter.content

--- a/app/views/records/dashboard.html.slim
+++ b/app/views/records/dashboard.html.slim
@@ -59,12 +59,18 @@ li.border-b.py-4
                   / 時間表示の条件分岐(40分以上は時間表示、35分以下はメモのみ)
                   - show_time = total_minutes >= 40
                   
+                  / 15分以下はテキスト非表示、ブロックのみ表示
+                  - padding_class = total_minutes >= 40 ? "px-3 py-2" : total_minutes >= 20 ? "px-2 py-1" : "px-1 py-0"
+                  - show_content = total_minutes >= 20
+
                   = link_to edit_record_activity_path(@record, presenter.activity), \
-                    class: "activity-marker activity-marker-start block no-underline absolute left-0 right-0 bg-blue-100 hover:bg-blue-200 border-l-4 border-blue-500 px-3 py-2 transition", \
-                    style: "top: #{top_px}px; height: #{height_px}px; z-index: 10;"
+                    class: "activity-marker activity-marker-start block no-underline absolute left-0 right-0 bg-teal-100 hover:bg-teal-200 border-l-4 border-teal-400 #{padding_class} transition overflow-hidden", \
+                    style: "top: #{top_px}px; height: #{height_px}px; z-index: 10;", \
+                    title: "#{presenter.time_range} #{presenter.content}"
                     - if show_time
-                      .font-medium.text-sm.text-gray-700 = presenter.time_range
-                    .mt-1.text-sm.text-gray-600 = presenter.content
+                      .font-medium.text-sm.text-gray-700.truncate = presenter.time_range
+                    - if show_content
+                      div class="text-xs text-gray-600 truncate" = presenter.content
               
               / 継続の時間帯には追加ボタンを表示(開始時刻以外)
               - if @activities_by_hour[hour].all? { |p| !p.start? }

--- a/app/views/static_pages/updates.html.slim
+++ b/app/views/static_pages/updates.html.slim
@@ -3,6 +3,18 @@
     h1.text-3xl.font-bold.text-brand-dark.mb-8.text-center リリース情報
 
     .space-y-6
+      / v1.1.1
+      .bg-white.rounded-xl.shadow-sm.p-8.md:p-16.border.border-gray-200
+        .flex.items-center.justify-between.mb-4
+          span.text-xl.font-bold.text-indigo-600 v1.1.1
+          span.text-sm.text-gray-400 2026.05.07
+        ul.list-disc.list-outside.pl-5.space-y-2.text-gray-600
+          li
+            | カレンダー表示の修正
+            p.mt-1.text-sm.text-gray-500
+              | 予定の開始時間によって、イベントがカレンダーの正しい位置に表示されない問題を修正しました。
+
+    .space-y-6.pt-12.mt-12
       / v1.1.0 
       .bg-white.rounded-xl.shadow-sm.p-8.md:p-16.border.border-gray-200
         .flex.items-center.justify-between.mb-4


### PR DESCRIPTION
## 概要
カレンダーの予約イベントが正しい時間位置に表示されない。

## 修正点 or 変更内容
**分単位のオフセット未反映**
- `top: 0`の固定値が分のオフセットを無視していたため修正しました。

## 動作確認
- カレンダーの予約イベントが正しい時間位置に表示されていること
 ![](https://i.gyazo.com/a5d69e7ccfe73467348dc792dc2e50a4.gif)

Resolves #63 